### PR TITLE
Prevent parallel initialize calls

### DIFF
--- a/src/test/java/TestRaceCondition.java
+++ b/src/test/java/TestRaceCondition.java
@@ -1,0 +1,29 @@
+import org.junit.Assert;
+import org.junit.Test;
+
+import ip3country.CountryLookup;
+
+import java.util.concurrent.*;
+
+public class TestRaceCondition {
+    @Test
+    public void testConcurrency() throws InterruptedException {
+        int threadCount = 50;
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            new Thread(() -> {
+                try {
+                    CountryLookup.lookupIPString("1.2.3.4");
+                    latch.countDown();
+                } catch (Exception ignored) {
+                    // noop
+                }
+            }).start();
+        }
+
+        if (!latch.await(1, TimeUnit.SECONDS)) {
+            Assert.fail();
+        }
+    }
+}


### PR DESCRIPTION
Fixes a bug where two threads could call CountryLookup.initialize(), leading to issues where both would be editing `countryTable`